### PR TITLE
Use consonant-only drops and free vowels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Spellfall basic setup. Run with local server.
 
+Falling letters are consonants only. Players may use any vowels freely when forming words.
+
 # How to run
 Start a python server in the root directory
 ```python3 -m http.server 8888```

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
     </div>
     <div id="startScreen" class="overlay visible">
       <h1 class="title">Spellfall</h1>
-      <p class="subtitle">Make words from falling letters. Press Enter to submit.</p>
+      <p class="subtitle">Make words using falling consonants. Vowels are free. Press Enter to submit.</p>
       <button id="startBtn" class="btn">Start</button>
-      <p class="hint">Tip: use Backspace to edit. Words must be 3+ letters.</p>
+      <p class="hint">Tip: use Backspace to edit. Words must be 3+ letters. Vowels are free!</p>
     </div>
     <div id="gameOverScreen" class="overlay hidden">
       <h2 class="title">Game Over</h2>

--- a/src/game.js
+++ b/src/game.js
@@ -2,7 +2,7 @@ import { Config } from './config.js';
 import { Renderer } from './render.js';
 import { nextLetter } from './spawn.js';
 import { scoreWord } from './scoring.js';
-const VOWELS = new Set(['A','E','I','O','U']);
+import { VOWELS } from './letters.js';
 
 export class Game {
   constructor(c) {

--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,7 @@ import { Config } from './config.js';
 import { Renderer } from './render.js';
 import { nextLetter } from './spawn.js';
 import { scoreWord } from './scoring.js';
+const VOWELS = new Set(['A','E','I','O','U']);
 
 export class Game {
   constructor(c) {
@@ -59,6 +60,7 @@ export class Game {
       counts[L.ch] = (counts[L.ch] || 0) + 1;
     }
     for (const ch of w) {
+      if (VOWELS.has(ch)) continue;
       if ((counts[ch] || 0) <= 0) return false;
       counts[ch]--;
     }
@@ -68,6 +70,7 @@ export class Game {
   consume(w) {
     const need = {};
     for (const ch of w) {
+      if (VOWELS.has(ch)) continue;
       need[ch] = (need[ch] || 0) + 1;
     }
     this.letters = this.letters.filter(L => {

--- a/src/letters.js
+++ b/src/letters.js
@@ -1,0 +1,2 @@
+export const VOWELS=new Set(['A','E','I','O','U']);export const CONSONANTS=[...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'].filter(c=>!VOWELS.has(c));
+

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,1 +1,1 @@
-import {Config} from './config.js';const uni='ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');export function nextLetter(){return uni[Math.floor(Math.random()*uni.length)];}
+const consonants='BCDFGHJKLMNPQRSTVWXYZ'.split('');export function nextLetter(){return consonants[Math.floor(Math.random()*consonants.length)];}

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,1 +1,1 @@
-const consonants='BCDFGHJKLMNPQRSTVWXYZ'.split('');export function nextLetter(){return consonants[Math.floor(Math.random()*consonants.length)];}
+import{CONSONANTS}from'./letters.js';export function nextLetter(){return CONSONANTS[Math.floor(Math.random()*CONSONANTS.length)];}


### PR DESCRIPTION
## Summary
- Spawn only consonants and allow vowels without consuming letters
- Update game logic so vowels are ignored when checking and consuming letters
- Clarify free-vowel rule in start screen and README

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0b845edb88322970a7073c336e1b1