### PR TITLE
Move HUD below game and add configurable score color

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,6 @@
   <div id="app" class="app">
     <canvas id="game" width="800" height="600"></canvas>
     <div id="flash" class="flash"></div>
-    <div id="hud" class="hud">
-      <div id="timer" class="hud-left">Time: <span id="timeValue">--</span></div>
-      <div id="score" class="hud-right">Score: <span id="scoreValue">0</span></div>
-    </div>
     <div id="startScreen" class="overlay visible">
       <h1 class="title">Spellfall</h1>
       <p class="subtitle">Make words using falling consonants. Vowels are free. Press Enter to submit.</p>
@@ -27,7 +23,11 @@
       <button id="restartBtn" class="btn">Start Game</button>
       <p class="final-score">Final Score: <span id="finalScore">0</span></p>
     </div>
+  </div>
+  <div id="hud" class="hud">
+    <div id="timer" class="hud-left">Time: <span id="timeValue">--</span></div>
     <div id="assemblyBar" class="assembly"></div>
+    <div id="score" class="hud-right">Score: <span id="scoreValue">0</span></div>
   </div>
   <script type="module">
     import { Game } from './src/game.js';
@@ -45,6 +45,8 @@
     const timeValue = document.getElementById('timeValue');
     const finalScore = document.getElementById('finalScore');
     const flash = document.getElementById('flash');
+    const scoreEl = document.getElementById('score');
+    scoreEl.style.color = Config.SCORE_COLOR;
     initInput({
       onLetter: (ch) => game.onLetter(ch),
       onBackspace: () => game.onBackspace(),

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,8 @@ export const Config={
 	LOW_TIME_THRESHOLD_SEC:3,
 	FONT_FAMILY:'600 28px sans-serif',
 	LETTER_STYLE:'#e5e7eb',
-	BG_COLOR:'#014A82',
-	LETTER_FREQ_MODE:'uniform'
+        BG_COLOR:'#014A82',
+        LETTER_FREQ_MODE:'uniform',
+        SCORE_COLOR:'#30a200'
 };
 

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,14 @@
 :root{--bg:#111827;--panel:#0b1220;--text:#e5e7eb;--accent:#60a5fa;--good:#10b981;--bad:#ef4444;--lowtime:#f59e0b;}
-body{margin:0;background:var(--bg);color:var(--text);font-family:sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;}
+body{margin:0;background:var(--bg);color:var(--text);font-family:sans-serif;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;}
 .app{position:relative;width:800px;height:600px;background:var(--panel);border-radius:16px;overflow:hidden;}
 #game{display:block;background:#0f172a;}
-.hud{position:absolute;left:0;right:0;bottom:8px;padding:0 12px;display:flex;justify-content:space-between;font-size:24px;font-weight:800;z-index:1;}
+.hud{margin-top:8px;width:800px;display:flex;align-items:center;font-size:24px;font-weight:800;}
+.hud-left{flex:1;text-align:left;}
 .hud-left.low{color:var(--lowtime);}
+.assembly{flex:1;text-align:center;font-size:24px;font-weight:800;}
+.hud-right{flex:1;text-align:right;}
 .overlay{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);}
 .overlay.hidden{display:none;}
 .btn{background:var(--accent);color:#0b1220;border:none;border-radius:12px;padding:10px 18px;font-weight:700;cursor:pointer;}
-.assembly{position:absolute;left:0;right:0;bottom:8px;text-align:center;font-size:24px;font-weight:800;}
 .assembly.ok{color:var(--good);}.assembly.bad{color:var(--bad);}
 .flash{position:absolute;inset:0;background:var(--good);opacity:0;pointer-events:none;z-index:100;}


### PR DESCRIPTION
## Summary
- Relocated HUD elements below the canvas so falling letters no longer overlap game info
- Added configurable SCORE_COLOR option and applied default #30a200 to score display

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a12f4233ac8322a90965c53b910026