### PR TITLE
feat: jazz up start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css"/>
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg"/>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <div id="app" class="app">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Spellfall</title>
   <link rel="stylesheet" href="styles.css"/>
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg"/>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
 </head>
 <body>
   <div id="app" class="app">

--- a/styles.css
+++ b/styles.css
@@ -50,3 +50,7 @@ body::before{
 .btn:hover{
   transform:scale(1.1);
 }
+
+.subtitle,.hint{
+  font-family:'VT323',monospace;
+}

--- a/styles.css
+++ b/styles.css
@@ -12,3 +12,41 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:sans-serif;disp
 .btn{background:var(--accent);color:#0b1220;border:none;border-radius:12px;padding:10px 18px;font-weight:700;cursor:pointer;}
 .assembly.ok{color:var(--good);}.assembly.bad{color:var(--bad);}
 .flash{position:absolute;inset:0;background:var(--good);opacity:0;pointer-events:none;z-index:100;}
+/* Fun background with subtle moving stars */
+body::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  background-image:
+    radial-gradient(#ffffff0d 1px,#0000 1px),
+    radial-gradient(#ffffff0d 1px,#0000 1px);
+  background-size:50px 50px;
+  background-position:0 0,25px 25px;
+  animation:bg-scroll 30s linear infinite;
+  pointer-events:none;
+  z-index:-1;
+}
+@keyframes bg-scroll{
+  from{background-position:0 0,25px 25px;}
+  to{background-position:-50px -50px,-25px -25px;}
+}
+
+/* Retro title glow */
+.title{
+  font-family:'Press Start 2P',cursive;
+  text-shadow:0 0 8px var(--accent),0 0 16px var(--accent);
+  animation:title-glow 2s ease-in-out infinite alternate;
+}
+@keyframes title-glow{
+  from{text-shadow:0 0 8px var(--accent),0 0 16px var(--accent);}
+  to{text-shadow:0 0 16px var(--accent),0 0 24px var(--accent);}
+}
+
+/* Button hover animation */
+.btn{
+  box-shadow:0 0 8px var(--accent);
+  transition:transform .2s;
+}
+.btn:hover{
+  transform:scale(1.1);
+}


### PR DESCRIPTION
## Summary
- Add retro arcade font for title and UI
- Introduce animated starfield background and glowing title
- Enhance buttons with hover scaling and accent glow

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1328ecea48322805f8681f2e063be